### PR TITLE
Hide portlet for unprivileged users when there are no labels.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,7 +6,8 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Hide portlet for unprivileged users when there are no labels.
+  [jone]
 
 
 1.0.1 (2014-06-23)

--- a/ftw/labels/portlets/labeljar.py
+++ b/ftw/labels/portlets/labeljar.py
@@ -23,6 +23,8 @@ class Renderer(Renderer):
             return False
         if not ILabelRoot.providedBy(self.context):
             return False
+        if not self.can_edit and not self.labels:
+            return False
         return True
 
     @property

--- a/ftw/labels/tests/test_jar_portlet.py
+++ b/ftw/labels/tests/test_jar_portlet.py
@@ -27,8 +27,16 @@ class LabelJarPortletFunctionalTest(TestCase):
     @browsing
     def test_protlet_is_enabled_if_ILabelRoot_is_provided(self, browser):
         folder = create(Builder('label root'))
-        browser.visit(folder)
+        browser.login().visit(folder)
         self.assertTrue(jarportlet.portlet())
+
+    @browsing
+    def test_invisible_for_unprivileged_users_when_empty(self, browser):
+        folder = create(Builder('label root'))
+        browser.visit(folder)
+        self.assertFalse(
+            jarportlet.portlet(),
+            'Anonymous users should not see labels portlet when it is empty.')
 
     @browsing
     def test_list_all_labels_in_the_jar(self, browser):


### PR DESCRIPTION
The portlet is not displayed anymore for users which can not add labels, if there are no labels.
Fixes #36 
// @ninfaj 
