### PR TITLE
Do not redirect to referer when updating the labels jar.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,7 +6,9 @@ Changelog
 1.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Do not redirect to referer when updating the labels jar.
+  The referer is usually the form submitting the change.
+  [jone]
 
 
 1.0.2 (2014-06-24)

--- a/ftw/labels/browser/labelsjar.py
+++ b/ftw/labels/browser/labelsjar.py
@@ -83,11 +83,7 @@ class LabelsJar(BrowserView):
 
     def _redirect(self):
         response = self.request.RESPONSE
-        referer = self.request.get('HTTP_REFERER')
-        if referer and referer is not 'localhost':
-            response.redirect(referer)
-        else:
-            response.redirect(self.context.absolute_url())
+        return response.redirect(self.context.absolute_url())
 
     def _get_random_color(self):
         all_colors = list(COLORS)


### PR DESCRIPTION
The referer is usually the form submitting the change.
But we want to redirect to the default view of the current context.

Background:
- The refere, redirecting back to the submitting form, may be invalid because the label ID is missing.
- ftw.testbrowser now [submits the referer correctly](https://github.com/4teamwork/ftw.testbrowser/commit/4f5a6863ac467c68bbf4c039b5d5559f823b84ed), which exposed this problem.
- The problem was not visible in production since we do AJAX requests and the redirect is not relevant because the overlay with the form is closed - the production keeps the same behavior.
