### PR TITLE
Do not show label configuration button for not permitted users.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,10 @@ Changelog
 1.0.3 (unreleased)
 ------------------
 
+- Do not show label configuration button for not permitted users.
+  https://github.com/4teamwork/ftw.labels/issues/39
+  [elioschmutz]
+
 - Do not redirect to referer when updating the labels jar.
   The referer is usually the form submitting the change.
   [jone]

--- a/ftw/labels/portlets/labeljar.pt
+++ b/ftw/labels/portlets/labeljar.pt
@@ -14,6 +14,7 @@
                            data-color label/color">
         <span class="labelTitle" tal:content="label/title" />
         <a class="editLabelLink"
+           tal:condition="can_edit"
            tal:attributes="href string:${here/absolute_url}/labels-jar/edit_label?label_id=${label/label_id}"
            i18n:translate="label_editlabel">
           edit label

--- a/ftw/labels/tests/test_jar_portlet.py
+++ b/ftw/labels/tests/test_jar_portlet.py
@@ -76,7 +76,7 @@ class LabelJarPortletFunctionalTest(TestCase):
 
     @browsing
     def test_user_without_permission_cant_view_jar_edit_elements(self, browser):
-        folder = create(Builder('label root'))
+        folder = create(Builder('label root').with_labels(('James', 'red')))
         reader = create(Builder('user').with_roles('Reader'))
         browser.login(reader).visit(folder)
 


### PR DESCRIPTION
@jone 

Fix: Do not show label configuration button for not permitted users.

closes #39 