### PR TITLE
Add ILabelJarChild interface to inherit labels of a parents ILabelJar

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,20 @@ For objects providing ``ILabelSupport`` a right-column-portlet is added
 on the root of the Plone site which allows to manage labels.
 
 
+Add the ``ILabelJarChild`` marker interface to any container class to
+display the labels stored in a parents ``ILabelJar``
+
+.. code:: xml
+
+    <class class="Products.ATContentTypes.content.folder.ATFolder">
+        <implements interface="ftw.labels.interfaces.ILabelJarChild" />
+    </class>
+
+For objects providing ``ILabelJarChild`` you can manage and store the
+same labels as defined in the ``ILabelJar`` content without defining
+a new ``ILabelRoot``
+
+
 Uninstall
 ---------
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,10 @@ Changelog
 1.0.3 (unreleased)
 ------------------
 
+- Add ILabelJarChild interface to inherit labels of a parents ILabelJar
+  https://github.com/4teamwork/ftw.labels/issues/41
+  [elioschmutz]
+
 - Do not show label configuration button for not permitted users.
   https://github.com/4teamwork/ftw.labels/issues/39
   [elioschmutz]

--- a/ftw/labels/adapters.zcml
+++ b/ftw/labels/adapters.zcml
@@ -13,4 +13,5 @@
 
     <adapter factory=".indexer.labels" name="labels" />
 
+    <interface interface="ftw.labels.interfaces.ILabelJarChild" />
 </configure>

--- a/ftw/labels/interfaces.py
+++ b/ftw/labels/interfaces.py
@@ -14,6 +14,12 @@ class ILabelSupport(Interface):
     """
 
 
+class ILabelJarChild(Interface):
+    """Marker interface for objects which should display the labelsjar
+    portlet of a parents ``ILabelRoot``
+    """
+
+
 class ILabelJar(Interface):
     """Adapter interface for label roots (``ILabelRoot``), providing
     an interface for managing available labels for this label ecosystem.

--- a/ftw/labels/portlets/labeljar.py
+++ b/ftw/labels/portlets/labeljar.py
@@ -1,4 +1,5 @@
 from ftw.labels.config import COLORS
+from ftw.labels.interfaces import ILabelJarChild
 from ftw.labels.interfaces import ILabelJar
 from ftw.labels.interfaces import ILabelRoot
 from ftw.labels.portlets.assignments import LabelJarAssignment
@@ -21,7 +22,10 @@ class Renderer(Renderer):
     def available(self):
         if 'portal_factory' in self.context.absolute_url():
             return False
-        if not ILabelRoot.providedBy(self.context):
+        if ILabelJarChild.providedBy(self.context):
+            if not self.label_root_obj:
+                return False
+        elif not ILabelRoot.providedBy(self.context):
             return False
         if not self.can_edit and not self.labels:
             return False
@@ -29,7 +33,7 @@ class Renderer(Renderer):
 
     @property
     def labels(self):
-        return ILabelJar(self.context).list()
+        return ILabelJar(self.label_root_obj).list()
 
     @property
     def colors(self):
@@ -40,3 +44,10 @@ class Renderer(Renderer):
         mtool = getToolByName(self.context, 'portal_membership')
         return mtool.checkPermission(
             'ftw.labels: Manage Labels Jar', self.context)
+
+    @property
+    def label_root_obj(self):
+        try:
+            return ILabelJar(self.context)
+        except LookupError:
+            return None

--- a/ftw/labels/tests/builders.py
+++ b/ftw/labels/tests/builders.py
@@ -1,9 +1,10 @@
 from ftw.builder import builder_registry
 from ftw.builder.archetypes import ArchetypesBuilder
+from ftw.labels.interfaces import ILabelJarChild
+from ftw.labels.interfaces import ILabeling
 from ftw.labels.interfaces import ILabelJar
 from ftw.labels.interfaces import ILabelRoot
 from ftw.labels.interfaces import ILabelSupport
-from ftw.labels.interfaces import ILabeling
 import transaction
 
 
@@ -31,6 +32,18 @@ class LabelRootBuilder(ArchetypesBuilder):
 
 
 builder_registry.register('label root', LabelRootBuilder)
+
+
+class LabelDisplayBuilder(ArchetypesBuilder):
+
+    portal_type = 'Folder'
+
+    def __init__(self, *args, **kwargs):
+        super(LabelDisplayBuilder, self).__init__(*args, **kwargs)
+        self.providing(ILabelJarChild)
+
+
+builder_registry.register('label display', LabelDisplayBuilder)
 
 
 class LabelledPageBuilder(ArchetypesBuilder):

--- a/ftw/labels/tests/test_jar_portlet.py
+++ b/ftw/labels/tests/test_jar_portlet.py
@@ -31,6 +31,35 @@ class LabelJarPortletFunctionalTest(TestCase):
         self.assertTrue(jarportlet.portlet())
 
     @browsing
+    def test_protlet_is_enabled_if_ILabelJarChild_and_parent_is_ILabelRoot(self, browser):
+        folder = create(Builder('label root'))
+        subfolder = create(Builder('label display').within(folder))
+
+        browser.login().visit(subfolder)
+        self.assertTrue(jarportlet.portlet())
+
+    @browsing
+    def test_invisible_ILabelJarChild_without_parent_ILabelRoot(self, browser):
+        folder = create(Builder('label display'))
+
+        browser.login().visit(folder)
+        self.assertFalse(
+            jarportlet.portlet(),
+            "The folder can't show the portlet because "
+            "it has no parent label root folder")
+
+    @browsing
+    def test_invisible_if_no_ILabelJarChild_but_parent_with_ILabelRoot(self, browser):
+        folder = create(Builder('label root'))
+        subfolder = create(Builder('folder').within(folder))
+
+        browser.login().visit(subfolder)
+        self.assertFalse(
+            jarportlet.portlet(),
+            "The folder shouldn't show the portlet because "
+            "it has no ILabelJarChild marker interface")
+
+    @browsing
     def test_invisible_for_unprivileged_users_when_empty(self, browser):
         folder = create(Builder('label root'))
         browser.visit(folder)
@@ -43,6 +72,18 @@ class LabelJarPortletFunctionalTest(TestCase):
         folder = create(Builder('label root')
                         .with_labels(('Label 1', ''), ('Label 2', '')))
         browser.visit(folder)
+        self.assertItemsEqual(
+            ['Label 1', 'Label 2'],
+            jarportlet.labels().keys())
+
+    @browsing
+    def test_list_same_labels_in_the_labeldisplay_folder(self, browser):
+        folder = create(Builder('label root')
+                        .with_labels(('Label 1', ''), ('Label 2', '')))
+
+        subfolder = create(Builder('label display').within(folder))
+
+        browser.visit(subfolder)
         self.assertItemsEqual(
             ['Label 1', 'Label 2'],
             jarportlet.labels().keys())


### PR DESCRIPTION
@jone 

If you add the ILabelJarChild interface to a child object of a ILabelJar, it will display and manage the same label ecosystem.

LabelJar
------------
![bildschirmfoto 2015-10-16 um 14 24 48](https://cloud.githubusercontent.com/assets/557005/10541492/e5549b18-7411-11e5-99ab-7283e5996b04.png)

Subfolder with the ILabelJarChild interface
--------------------------------------------------------
![bildschirmfoto 2015-10-16 um 14 24 53](https://cloud.githubusercontent.com/assets/557005/10541493/e555e928-7411-11e5-998f-bf6624a716eb.png)

Subfolder with own ILabelJar interface
---------------------------------------------------
![bildschirmfoto 2015-10-16 um 14 25 00](https://cloud.githubusercontent.com/assets/557005/10541494/e55622f8-7411-11e5-9768-aa99dcdddd97.png)

closes #41 