### PR TITLE
Fix js error if you click on a label in the labels-jar portlet on a page without a tabbedview

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,7 +6,10 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix labeljar portlet if you use it without ftw.table.
+  The javascript for the ftw.table-integration was executed
+  even if you don't have an ftw.table.
+  [elioschmutz]
 
 
 1.1.0 (2016-03-21)

--- a/ftw/labels/browser/resources/ftw-labels.js
+++ b/ftw/labels/browser/resources/ftw-labels.js
@@ -21,13 +21,13 @@ $(document).ready(function(){
   });
 
   $('.labelItem').click(function() {
-    if(typeof(tabbedview) == undefined) {
-      return;
-    }
-
     $(this).toggleClass('selected');
     $(this).toggleClass(
       'labelcolor-' + $(this).find('.labelColor').data('color'));
+
+    if( window.tabbedview === undefined ) {
+      return;
+    }
 
     var labels_prop;
     if (tabbedview.prop('labels')) {


### PR DESCRIPTION
closes #47 