### PR TITLE
Redirect to HTTP_REFERER instead context.absolute_url

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,7 +7,9 @@ Changelog
 
 - Added French translations.
   [gbastien]
-
+- Redirect to HTTP_REFERER instead context.absolute_url after a label is
+  added using the labejar portlet.
+  [gbastien]
 
 1.1.1 (2017-02-09)
 ------------------

--- a/ftw/labels/browser/labelsjar.py
+++ b/ftw/labels/browser/labelsjar.py
@@ -89,7 +89,8 @@ class LabelsJar(BrowserView):
 
     def _redirect(self):
         response = self.request.RESPONSE
-        return response.redirect(self.context.absolute_url())
+        referer = self.request.get('HTTP_REFERER')
+        return response.redirect(referer)
 
     def _get_random_color(self):
         all_colors = list(COLORS)

--- a/ftw/labels/browser/labelsjar.py
+++ b/ftw/labels/browser/labelsjar.py
@@ -89,7 +89,7 @@ class LabelsJar(BrowserView):
 
     def _redirect(self):
         response = self.request.RESPONSE
-        referer = self.request.get('HTTP_REFERER')
+        referer = self.request.get('HTTP_REFERER', self.context.absolute_url())
         return response.redirect(referer)
 
     def _get_random_color(self):


### PR DESCRIPTION
 after a label is added using the labejar portlet.