### PR TITLE
Fix redirecting and tests.

### DIFF
--- a/ftw/labels/browser/labelsjar.py
+++ b/ftw/labels/browser/labelsjar.py
@@ -67,7 +67,7 @@ class LabelsJar(BrowserView):
             raise BadRequest('The "label_id" request argument is required.')
 
         ILabelJar(self.context).remove(label_id)
-        return self._redirect()
+        return self._redirect(consider_referer=False)
 
     def edit_label(self):
         """Form for editing a label.
@@ -87,10 +87,13 @@ class LabelsJar(BrowserView):
             light='{0}-light'.format(color)
             ) for color in COLORS]
 
-    def _redirect(self):
-        response = self.request.RESPONSE
-        referer = self.request.get('HTTP_REFERER', self.context.absolute_url())
-        return response.redirect(referer)
+    def _redirect(self, consider_referer=True):
+        target_url = None
+        if consider_referer:
+            target_url = self.request.get('HTTP_REFERER')
+        if not target_url:
+            target_url = self.context.absolute_url()
+        return self.request.RESPONSE.redirect(target_url)
 
     def _get_random_color(self):
         all_colors = list(COLORS)

--- a/ftw/labels/tests/test_jar_management_view.py
+++ b/ftw/labels/tests/test_jar_management_view.py
@@ -143,8 +143,7 @@ class TestLabelsJar(TestCase):
                       .with_labels(('Feature', 'blue')))
 
         browser.login().open(root,
-                             view='labels-jar/edit_label',
-                             data={'label_id': 'feature'})
+                             view='labels-jar/edit_label?label_id=feature')
 
         browser.fill({'title': 'Features and inquiries'}).submit()
 
@@ -160,8 +159,7 @@ class TestLabelsJar(TestCase):
                       .with_labels(('Feature', 'blue')))
 
         browser.login().open(root,
-                             view='labels-jar/edit_label',
-                             data={'label_id': 'feature'})
+                             view='labels-jar/edit_label?label_id=feature')
 
         browser.fill({'color': 'green'}).submit()
 
@@ -177,8 +175,7 @@ class TestLabelsJar(TestCase):
                       .with_labels(('Feature', 'blue')))
 
         browser.login().open(root,
-                             view='labels-jar/edit_label',
-                             data={'label_id': 'feature'})
+                             view='labels-jar/edit_label?label_id=feature')
 
         browser.find('Delete label').click()
 


### PR DESCRIPTION
The referer in the overlay is actually incorrect, because it is not
embedded in a frame and therefore actually uses the referer of the
parent page.

The testbrowser does not support overlays (nor JavaScript) and
therefore directly tested the view, using different referers.

Also the fallback to the absolute url did not work because the
request's get method does not use the default value as expected.