### PR TITLE
Fix testing.

### DIFF
--- a/ftw/labels/tests/test_builders.py
+++ b/ftw/labels/tests/test_builders.py
@@ -5,7 +5,7 @@ from ftw.labels.interfaces import ILabeling
 from ftw.labels.testing import LABELS_FUNCTIONAL_TESTING
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import setRoles
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 class TestTestingBuidlers(TestCase):

--- a/ftw/labels/tests/test_catalog.py
+++ b/ftw/labels/tests/test_catalog.py
@@ -4,7 +4,7 @@ from ftw.builder import create
 from ftw.labels.testing import LABELS_FUNCTIONAL_TESTING
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import setRoles
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 class TestCatalogIndex(TestCase):

--- a/ftw/labels/tests/test_jar.py
+++ b/ftw/labels/tests/test_jar.py
@@ -6,7 +6,7 @@ from zope.annotation import IAttributeAnnotatable
 from zope.component import queryAdapter
 from plone.mocktestcase.dummy import Dummy
 from zope.interface.verify import verifyClass
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.interface import alsoProvides
 
 

--- a/ftw/labels/tests/test_jar_discovery.py
+++ b/ftw/labels/tests/test_jar_discovery.py
@@ -11,15 +11,13 @@ class TestJarDiscovery(MockTestCase):
 
     def test_adapting_root_returns_jar(self):
         root = self.providing_stub(ILabelRoot)
-        self.replay()
         jar = ILabelJar(root)
         self.assertIsInstance(jar, LabelJar)
 
     def test_walks_up_the_acquisition_for_finding_jar(self):
         root = self.providing_stub(ILabelRoot)
         folder = self.set_parent(self.stub(), root)
-        document =  self.set_parent(self.stub(), folder)
-        self.replay()
+        document = self.set_parent(self.stub(), folder)
 
         jar = ILabelJar(document)
         self.assertIsInstance(jar, LabelJar)
@@ -28,8 +26,6 @@ class TestJarDiscovery(MockTestCase):
     def test_raise_when_app_is_reached(self):
         app = self.providing_stub(IApplication)
         document = self.set_parent(self.stub(), app)
-        self.replay()
-
         with self.assertRaises(LookupError) as cm:
             ILabelJar(document)
 

--- a/ftw/labels/tests/test_jar_management_view.py
+++ b/ftw/labels/tests/test_jar_management_view.py
@@ -7,7 +7,7 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import statusmessages
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import setRoles
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 class TestLabelsJar(TestCase):

--- a/ftw/labels/tests/test_jar_portlet.py
+++ b/ftw/labels/tests/test_jar_portlet.py
@@ -7,7 +7,7 @@ from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import login
 from plone.app.testing import setRoles
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 class LabelJarPortletFunctionalTest(TestCase):

--- a/ftw/labels/tests/test_labeling.py
+++ b/ftw/labels/tests/test_labeling.py
@@ -24,7 +24,6 @@ class TestLabeling(MockTestCase):
         self.document = self.providing_stub([ILabelSupport,
                                              IAttributeAnnotatable])
         self.set_parent(self.document, self.root)
-        self.replay()
         self.jar = ILabelJar(self.root)
 
     def test_adapter(self):

--- a/ftw/labels/tests/test_labeling_management_view.py
+++ b/ftw/labels/tests/test_labeling_management_view.py
@@ -6,7 +6,7 @@ from ftw.labels.testing import LABELS_FUNCTIONAL_TESTING
 from ftw.testbrowser import browsing
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import setRoles
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 class TestLabelingView(TestCase):

--- a/ftw/labels/tests/test_labeling_viewlet.py
+++ b/ftw/labels/tests/test_labeling_viewlet.py
@@ -6,7 +6,7 @@ from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import login
 from plone.app.testing import setRoles
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 class TestLabelingViewlet(TestCase):

--- a/ftw/labels/tests/test_uninstall.py
+++ b/ftw/labels/tests/test_uninstall.py
@@ -1,6 +1,6 @@
 from ftw.testing.genericsetup import GenericSetupUninstallMixin
 from ftw.testing.genericsetup import apply_generic_setup_layer
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 @apply_generic_setup_layer

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ tests_require = [
     'asserts',
     'ftw.builder',
     'ftw.testbrowser',
-    'ftw.testing',
+    'ftw.testing>=2',
     'plone.app.testing',
     'plone.mocktestcase',
     'transaction',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ tests_require = [
     'plone.app.testing',
     'plone.mocktestcase',
     'transaction',
-    'unittest2',
     'zope.configuration'
     ]
 


### PR DESCRIPTION
- Use `unittest` instead of `unittest2`.
- Update to newest `ftw.testing`, replacing the mocker implemenation to use python standard lib `mock`.